### PR TITLE
Update purge options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,9 @@ yarn add nuxt-tailvue
 
 ```js
 module.exports = {
-    content: [
+    purge: [
       'node_modules/tv-*/dist/tv-*.umd.min.js',
+      ],
   }
 ```
 


### PR DESCRIPTION
As an alternative, it could be written with the object syntax:

```js
module.exports = {
  purge: {
    content: ['./src/**/*.html'],
  },
  // ...
}
```

What is important is to have `purge` section for it to work in prod mode (dev does not use purge by default).